### PR TITLE
Updated minimum guzzle version and requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "~2.1",
         "symfony/stopwatch": "~2.1",
 
-        "guzzlehttp/guzzle": "~5.2"
+        "guzzlehttp/guzzle": ">=4.0.0"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "1.4.2",

--- a/tests/Visithor/Client/GuzzleClientTest.php
+++ b/tests/Visithor/Client/GuzzleClientTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Visithor package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\tests\Visithor\Client;
+
+use PHPUnit_Framework_TestCase;
+
+use Visithor\Client\GuzzleClient;
+use Visithor\Model\Url;
+
+/**
+ * Class GuzzleClientTest
+ */
+class GuzzleClientTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test client
+     */
+    public function testClient()
+    {
+        $client = new GuzzleClient();
+        $client->buildClient();
+        $url = new Url(
+            'http://google.es',
+            [200],
+            []
+        );
+
+        $result = $client->getResponseHTTPCode($url);
+
+        $this->assertEquals(
+            200,
+            $result
+        );
+    }
+}


### PR DESCRIPTION
- Guzzle matches 4.\* and 5.*
